### PR TITLE
Fix for last Zanata upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ public MessageSource messageSource() {
     zanataMessageSource.setZanataBaseUrl("https://my-zanata.internal");
     zanataMessageSource.setProject("MY-ZANAZA-PROJECT");
     
-    //provide spring RestTemplate and apply ZanataAuthHeaderInterceptor
     RestTemplate restTemplate = new RestTemplate();
             restTemplate.getInterceptors()
                 .add(new ZanataAuthHeaderInterceptor("<username>", "<token>"));
+            
+    zanataMessageSource.setRestTemplate(restTemplate);           
     zanataMessageSource.setParentMessageSource(localMessageSource);
     return zanataMessageSource;
 }

--- a/README.md
+++ b/README.md
@@ -29,33 +29,12 @@ public MessageSource messageSource() {
     ZanataMessageSource zanataMessageSource = new ZanataMessageSource();
     zanataMessageSource.setZanataBaseUrl("https://my-zanata.internal");
     zanataMessageSource.setProject("MY-ZANAZA-PROJECT");
+    
+    //provide spring RestTemplate and apply ZanataAuthHeaderInterceptor
+    RestTemplate restTemplate = new RestTemplate();
+            restTemplate.getInterceptors()
+                .add(new ZanataAuthHeaderInterceptor("<username>", "<token>"));
     zanataMessageSource.setParentMessageSource(localMessageSource);
     return zanataMessageSource;
-}
-```
-
-## Authentication
-
-If your Zanata instance needs authentication for accessing translations you can set the `RestTemplate` with the authentication info provided.
-
-Here is an example interceptor:
-
-```java
-public class AuthInterceptor implements ClientHttpRequestInterceptor {
-
-    private final String apiUser;
-    private final String apiKey;
-
-    public AuthInterceptor(String user, String apiKey) {
-        this.apiUser = user;
-        this.apiKey = apiKey;
-    }
-
-    @Override
-    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
-        request.getHeaders().add("X-Auth-User", apiUser);
-        request.getHeaders().add("X-Auth-Token", apiKey);
-        return execution.execute(request, body);
-    }
 }
 ```

--- a/src/main/java/at/porscheinformatik/zanata/ZanataAuthHeaderInterceptor.java
+++ b/src/main/java/at/porscheinformatik/zanata/ZanataAuthHeaderInterceptor.java
@@ -1,0 +1,32 @@
+package at.porscheinformatik.zanata;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class ZanataAuthHeaderInterceptor implements ClientHttpRequestInterceptor {
+
+
+  private final String apiUser;
+  private final String apiToken;
+
+  public ZanataAuthHeaderInterceptor(String apiUser, String apiToken) {
+    this.apiUser = apiUser;
+    this.apiToken = apiToken;
+  }
+
+  @Override
+  public ClientHttpResponse intercept(HttpRequest httpRequest, byte[] bytes, ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
+
+    httpRequest.getHeaders().add("X-Auth-User", apiUser);
+    httpRequest.getHeaders().add("X-Auth-Token", apiToken);
+    httpRequest.getHeaders().setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+    return clientHttpRequestExecution.execute(httpRequest, bytes);
+  }
+}

--- a/src/main/java/at/porscheinformatik/zanata/ZanataAuthHeaderInterceptor.java
+++ b/src/main/java/at/porscheinformatik/zanata/ZanataAuthHeaderInterceptor.java
@@ -1,13 +1,11 @@
 package at.porscheinformatik.zanata;
 
 import org.springframework.http.HttpRequest;
-import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
-import java.util.Collections;
 
 public class ZanataAuthHeaderInterceptor implements ClientHttpRequestInterceptor {
 
@@ -25,7 +23,6 @@ public class ZanataAuthHeaderInterceptor implements ClientHttpRequestInterceptor
 
     httpRequest.getHeaders().add("X-Auth-User", apiUser);
     httpRequest.getHeaders().add("X-Auth-Token", apiToken);
-    httpRequest.getHeaders().setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
     return clientHttpRequestExecution.execute(httpRequest, bytes);
   }

--- a/src/main/java/at/porscheinformatik/zanata/ZanataMessageSource.java
+++ b/src/main/java/at/porscheinformatik/zanata/ZanataMessageSource.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.springframework.context.MessageSource;
@@ -39,7 +40,7 @@ public class ZanataMessageSource extends AbstractMessageSource implements AllPro
   private String iteration = "master";
 
   private final Set<String> basenameSet = new LinkedHashSet<>(singletonList("messages"));
-  private final Map<Locale, TranslationsResource[]> translationsCache = new HashMap<>();
+  private final Map<Locale, TranslationsResource[]> translationsCache = new ConcurrentHashMap<>();
 
   /**
    * @return the Zanata URL


### PR DESCRIPTION
- changed `translationsCache` from HashMap to ConcurrentHashMap, which allows us to clear the `translationsCache` during runtime
- added ZanataAuthIntercepter, which add `X-Auth-User`,` X-Auth-Token` headers. Also adds an `ACCEPT` header to force JSON results